### PR TITLE
Add speaker diarization with interactive role assignment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,22 @@ LLM_ENABLE_CLEANING=true
 # Extract TODOs by default: true, false
 # When false, TODOs only extracted via menu option or CLI flag
 LLM_EXTRACT_TODOS=false
+
+# Speaker Diarization Settings (requires sherpa-onnx; see setup.sh)
+# Distinguish voices and label transcript turns per speaker: true, false
+DIARIZATION_ENABLED=false
+
+# Path to the sherpa-onnx diarization binary
+DIARIZE_BINARY_PATH=sherpa-onnx/build/bin/sherpa-onnx-offline-speaker-diarization
+
+# Speaker segmentation model (pyannote segmentation-3.0, ONNX)
+DIARIZE_SEGMENTATION_MODEL=sherpa-onnx/models/sherpa-onnx-pyannote-segmentation-3-0/model.onnx
+
+# Speaker embedding model (3D-Speaker ERes2Net, ONNX)
+DIARIZE_EMBEDDING_MODEL=sherpa-onnx/models/3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx
+
+# Number of speakers, if known in advance (uncomment to fix; otherwise auto-detected)
+# DIARIZE_NUM_SPEAKERS=2
+
+# Clustering threshold for auto-detection; larger values yield fewer speakers
+DIARIZE_CLUSTER_THRESHOLD=0.5

--- a/setup.sh
+++ b/setup.sh
@@ -112,13 +112,18 @@ if ! command -v cmake &> /dev/null; then
     echo "Warning: cmake not found; skipping speaker diarization setup."
     echo "Install cmake and re-run setup.sh to enable diarization."
 else
+    # v1.10.30 pins onnxruntime 1.17.1, which links against older libstdc++
+    # (GCC 9 compatible); newer sherpa-onnx bundles an onnxruntime that
+    # requires GCC 11+.
+    SHERPA_ONNX_VERSION=v1.10.30
     if [ ! -d "sherpa-onnx" ]; then
-        echo "Cloning sherpa-onnx..."
-        git clone https://github.com/k2-fsa/sherpa-onnx.git
+        echo "Cloning sherpa-onnx ($SHERPA_ONNX_VERSION)..."
+        git clone --depth 1 --branch "$SHERPA_ONNX_VERSION" https://github.com/k2-fsa/sherpa-onnx.git
     else
-        echo "sherpa-onnx already exists, updating..."
+        echo "sherpa-onnx already exists, pinning $SHERPA_ONNX_VERSION..."
         cd sherpa-onnx
-        git pull
+        git fetch --depth 1 origin tag "$SHERPA_ONNX_VERSION"
+        git checkout "$SHERPA_ONNX_VERSION"
         cd ..
     fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -13,8 +13,11 @@ cd "$SCRIPT_DIR"
 # Configuration
 WHISPER_MODEL="${1:-base}"  # Default to base model
 LLAMA_MODEL_URL="https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf"
+# Note: "recongition" is a genuine typo in the upstream sherpa-onnx release tag
+DIARIZE_SEG_MODEL_URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-segmentation-models/sherpa-onnx-pyannote-segmentation-3-0.tar.bz2"
+DIARIZE_EMB_MODEL_URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-recongition-models/3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx"
 
-echo "Step 1/5: Checking system dependencies..."
+echo "Step 1/6: Checking system dependencies..."
 # Check for required tools
 if ! command -v git &> /dev/null; then
     echo "Error: git is not installed. Please install git first."
@@ -41,7 +44,7 @@ fi
 echo "✓ All required tools found"
 echo ""
 
-echo "Step 2/5: Building whisper.cpp..."
+echo "Step 2/6: Building whisper.cpp..."
 if [ ! -d "whisper.cpp" ]; then
     echo "Cloning whisper.cpp..."
     git clone https://github.com/ggerganov/whisper.cpp.git
@@ -58,7 +61,7 @@ make -j$(nproc)
 echo "✓ whisper.cpp built successfully"
 echo ""
 
-echo "Step 3/5: Downloading Whisper model ($WHISPER_MODEL)..."
+echo "Step 3/6: Downloading Whisper model ($WHISPER_MODEL)..."
 if [ ! -f "models/ggml-${WHISPER_MODEL}.bin" ]; then
     bash ./models/download-ggml-model.sh "$WHISPER_MODEL"
     echo "✓ Whisper model downloaded"
@@ -68,7 +71,7 @@ fi
 cd ..
 echo ""
 
-echo "Step 4/5: Building llama.cpp and downloading TinyLlama..."
+echo "Step 4/6: Building llama.cpp and downloading TinyLlama..."
 if [ ! -d "llama.cpp" ]; then
     echo "Cloning llama.cpp..."
     git clone https://github.com/ggerganov/llama.cpp.git
@@ -104,7 +107,60 @@ fi
 cd ..
 echo ""
 
-echo "Step 5/5: Building Haskell application..."
+echo "Step 5/6: Building sherpa-onnx and downloading diarization models..."
+if ! command -v cmake &> /dev/null; then
+    echo "Warning: cmake not found; skipping speaker diarization setup."
+    echo "Install cmake and re-run setup.sh to enable diarization."
+else
+    if [ ! -d "sherpa-onnx" ]; then
+        echo "Cloning sherpa-onnx..."
+        git clone https://github.com/k2-fsa/sherpa-onnx.git
+    else
+        echo "sherpa-onnx already exists, updating..."
+        cd sherpa-onnx
+        git pull
+        cd ..
+    fi
+
+    cd sherpa-onnx
+    echo "Building sherpa-onnx (fetches onnxruntime at configure time; needs network)..."
+    cmake -B build -DCMAKE_BUILD_TYPE=Release -DSHERPA_ONNX_ENABLE_TESTS=OFF
+    cmake --build build --config Release -j$(nproc) --target sherpa-onnx-offline-speaker-diarization
+    echo "✓ sherpa-onnx built successfully"
+
+    mkdir -p models
+
+    echo "Downloading speaker segmentation model (pyannote segmentation-3.0)..."
+    if [ ! -d "models/sherpa-onnx-pyannote-segmentation-3-0" ]; then
+        if [ $USE_CURL -eq 1 ]; then
+            curl -L "$DIARIZE_SEG_MODEL_URL" -o segmentation-model.tar.bz2
+        else
+            wget "$DIARIZE_SEG_MODEL_URL" -O segmentation-model.tar.bz2
+        fi
+        tar xf segmentation-model.tar.bz2 -C models
+        rm segmentation-model.tar.bz2
+        echo "✓ Segmentation model downloaded"
+    else
+        echo "✓ Segmentation model already exists"
+    fi
+
+    echo "Downloading speaker embedding model (3D-Speaker ERes2Net)..."
+    EMB_MODEL_FILE="models/$(basename "$DIARIZE_EMB_MODEL_URL")"
+    if [ ! -f "$EMB_MODEL_FILE" ]; then
+        if [ $USE_CURL -eq 1 ]; then
+            curl -L "$DIARIZE_EMB_MODEL_URL" -o "$EMB_MODEL_FILE"
+        else
+            wget "$DIARIZE_EMB_MODEL_URL" -O "$EMB_MODEL_FILE"
+        fi
+        echo "✓ Embedding model downloaded"
+    else
+        echo "✓ Embedding model already exists"
+    fi
+    cd ..
+fi
+echo ""
+
+echo "Step 6/6: Building Haskell application..."
 cabal update
 cabal build
 echo "✓ Haskell application built successfully"
@@ -117,6 +173,11 @@ echo ""
 echo "Models installed:"
 echo "  - Whisper: whisper.cpp/models/ggml-${WHISPER_MODEL}.bin"
 echo "  - LLM: llama.cpp/models/tinyllama-1.1b-chat.gguf"
+echo "  - Diarization: sherpa-onnx/models/ (segmentation + speaker embedding)"
+echo ""
+echo "Speaker diarization:"
+echo "  Set DIARIZATION_ENABLED=true in .env (or toggle it in the app menu)"
+echo "  to label transcript turns per speaker. Requires SAMPLE_RATE=16000."
 echo ""
 echo "To run the application:"
 echo "  cabal run whisper-hs"

--- a/src/STT/App.hs
+++ b/src/STT/App.hs
@@ -23,6 +23,8 @@ import STT.Config (AppConfig(..), Task(..))
 import qualified STT.Config as Config
 import qualified STT.Audio as Audio
 import qualified STT.Whisper as Whisper
+import qualified STT.Diarize as Diarize
+import qualified STT.LLM as LLM
 import qualified STT.Models as Models
 import qualified STT.PostProcess as PostProcess
 import qualified STT.Markdown as Markdown
@@ -52,14 +54,15 @@ runApp initialConfig = do
     putStrLn "  3. List audio devices"
     putStrLn "  4. Change language settings"
     putStrLn "  5. Change LLM model"
+    putStrLn "  6. Toggle speaker diarization"
     putStrLn ""
     putStrLn "Post-Processing:"
-    putStrLn "  6. Clean transcription file"
-    putStrLn "  7. Extract TODOs from file"
+    putStrLn "  7. Clean transcription file"
+    putStrLn "  8. Extract TODOs from file"
     putStrLn ""
-    putStrLn "  8. Quit"
+    putStrLn "  9. Quit"
     putStrLn ""
-    putStr "Choose an option (1-8): "
+    putStr "Choose an option (1-9): "
     hFlush stdout
 
     choice <- getLine
@@ -73,12 +76,13 @@ runApp initialConfig = do
       "3" -> listDevicesMenu
       "4" -> changeLanguageMenu configRef
       "5" -> changeLlmModelMenu configRef
-      "6" -> cleanTranscriptionMenu config
-      "7" -> extractTodosMenu config
-      "8" -> do
+      "6" -> toggleDiarizationMenu configRef
+      "7" -> cleanTranscriptionMenu config
+      "8" -> extractTodosMenu config
+      "9" -> do
         putStrLn "Goodbye!"
         exitSuccess
-      _ -> putStrLn "Invalid choice. Please choose 1-8."
+      _ -> putStrLn "Invalid choice. Please choose 1-9."
 
 -- | Print current configuration
 printConfig :: AppConfig -> IO ()
@@ -94,6 +98,7 @@ printConfig config = do
   putStrLn $ "  Task: " ++ show (task config)
   putStrLn $ "  Keep Recordings: " ++ show (keepRecordings config)
   putStrLn $ "  LLM Model: " ++ llmModelPath config
+  putStrLn $ "  Speaker Diarization: " ++ (if diarizationEnabled config then "Enabled" else "Disabled")
 
 -- | Menu for recording and transcribing
 recordAndTranscribeMenu :: AppConfig -> IO ()
@@ -156,9 +161,14 @@ recordAndTranscribe config duration deviceId = do
         Right transcription -> do
           displayTranscription config transcription
 
-          -- Clean up audio file if configured
+          -- Diarization needs the WAV, so it must run before cleanup
+          when (diarizationEnabled config) $
+            diarizeAndDisplay config audioPath transcription
+
+          -- Clean up audio file and whisper JSON sidecar if configured
           unless (keepRecordings config) $ do
             removeFile audioPath
+            removeIfExists (audioPath ++ ".json")
             putStrLn $ "Removed temporary file: " ++ audioPath
 
 -- | Transcribe an existing audio file
@@ -173,7 +183,10 @@ transcribeExistingFile config filePath = do
 
       case result of
         Left err -> putStrLn $ "Transcription error: " ++ err
-        Right transcription -> displayTranscription config transcription
+        Right transcription -> do
+          displayTranscription config transcription
+          when (diarizationEnabled config) $
+            diarizeAndDisplay config filePath transcription
 
 -- | Display transcription results
 displayTranscription :: AppConfig -> Whisper.TranscriptionResult -> IO ()
@@ -249,6 +262,7 @@ extractTodosMenu config = do
             { PostProcess.originalText = originalText
             , PostProcess.cleanedText = Nothing
             , PostProcess.todos = Just todos
+            , PostProcess.speakerTranscript = Nothing
             , PostProcess.processingErrors = []
             }
 
@@ -329,6 +343,112 @@ changeLlmModelMenu configRef = do
       putStrLn ""
       putStrLn "Updated configuration:"
       printConfig newConfig
+-- | Remove a file if it exists (whisper's -oj sidecar may or may not be there)
+removeIfExists :: FilePath -> IO ()
+removeIfExists path = do
+  exists <- doesFileExist path
+  when exists $ removeFile path
+
+-- | Run diarization, let the LLM suggest speaker roles, confirm them with
+-- the user, then display and save the speaker-labeled transcript
+diarizeAndDisplay :: AppConfig -> FilePath -> Whisper.TranscriptionResult -> IO ()
+diarizeAndDisplay config audioPath transcription = do
+  available <- Diarize.checkDiarizationAvailable config
+  case available of
+    Left hint -> putStrLn hint
+    Right () -> do
+      putStrLn "Identifying speakers..."
+      result <- Diarize.runDiarization config audioPath
+      case result of
+        Left err -> putStrLn $ "Diarization error: " ++ err
+        Right intervals -> do
+          let turns = Diarize.assignSpeakers intervals (Whisper.transSegments transcription)
+              speakers = Diarize.speakerLabels turns
+
+          putStrLn "\n========================================="
+          putStrLn "Speaker Transcript"
+          putStrLn "========================================="
+          TIO.putStrLn $ Diarize.renderSpeakerTurns [] turns
+
+          suggestions <- if llmEnableCleaning config
+            then do
+              putStrLn "\nSuggesting speaker roles..."
+              suggested <- LLM.suggestSpeakerRoles
+                             (llmBinaryPath config)
+                             (llmModelPath config)
+                             speakers
+                             (Diarize.renderSpeakerTurns [] turns)
+              case suggested of
+                Left err -> do
+                  putStrLn $ "Role suggestion failed: " ++ err
+                  return []
+                Right roles -> return roles
+            else return []
+
+          roleMap <- confirmRoles speakers suggestions turns
+          let finalTranscript = Diarize.renderSpeakerTurns roleMap turns
+
+          putStrLn "\n========================================="
+          putStrLn "Speaker Transcript (final)"
+          putStrLn "========================================="
+          TIO.putStrLn finalTranscript
+
+          -- Save alongside a timestamp so repeated runs don't clobber
+          timestamp <- formatTime defaultTimeLocale "%Y%m%d_%H%M%S" <$> getCurrentTime
+          let outputPath = "transcript_speakers_" ++ timestamp ++ ".md"
+              processedResult = PostProcess.ProcessedResult
+                { PostProcess.originalText = Whisper.transText transcription
+                , PostProcess.cleanedText = Nothing
+                , PostProcess.todos = Nothing
+                , PostProcess.speakerTranscript = Just finalTranscript
+                , PostProcess.processingErrors = []
+                }
+          Markdown.saveMeetingMinutes outputPath processedResult
+
+-- | Ask the user to confirm or override each suggested speaker role
+confirmRoles :: [T.Text] -> [(T.Text, T.Text)] -> [Diarize.SpeakerTurn] -> IO [(T.Text, T.Text)]
+confirmRoles speakers suggestions turns = do
+  putStrLn "\nAssign speaker roles (Enter accepts the suggestion, '-' keeps the plain label):"
+  concat <$> mapM askOne speakers
+  where
+    askOne speaker = do
+      let suggestion = lookup speaker suggestions
+          excerpt = case [Diarize.stText t | t <- turns, Diarize.stSpeaker t == speaker] of
+            (firstUtterance:_) -> T.take 80 firstUtterance
+            [] -> ""
+      putStrLn ""
+      putStrLn $ T.unpack speaker ++ ": \"" ++ T.unpack excerpt ++ "...\""
+      case suggestion of
+        Just role -> putStr $ "  Role [" ++ T.unpack role ++ "]: "
+        Nothing -> putStr "  Role (Enter to keep plain label): "
+      hFlush stdout
+      input <- getLine
+      return $ case (input, suggestion) of
+        ("-", _) -> []
+        ("", Just role) -> [(speaker, role)]
+        ("", Nothing) -> []
+        (typed, _) -> [(speaker, T.pack typed)]
+
+-- | Menu for toggling speaker diarization
+toggleDiarizationMenu :: IORef AppConfig -> IO ()
+toggleDiarizationMenu configRef = do
+  config <- readIORef configRef
+  let newEnabled = not (diarizationEnabled config)
+      newConfig = config { diarizationEnabled = newEnabled }
+
+  when newEnabled $ do
+    available <- Diarize.checkDiarizationAvailable config
+    case available of
+      Left hint -> putStrLn hint
+      Right () -> return ()
+    when (Config.unSampleRate (sampleRate config) /= 16000) $
+      putStrLn "Warning: sherpa-onnx expects 16 kHz audio; set SAMPLE_RATE=16000 for recordings you want to diarize."
+
+  writeIORef configRef newConfig
+  putStrLn $ "Speaker diarization " ++ (if newEnabled then "enabled." else "disabled.")
+  putStrLn ""
+  putStrLn "Updated configuration:"
+  printConfig newConfig
 
 -- | Menu for changing language settings
 changeLanguageMenu :: IORef AppConfig -> IO ()

--- a/src/STT/Config.hs
+++ b/src/STT/Config.hs
@@ -30,6 +30,8 @@ module STT.Config
   , parseStopSignal
   , parseTask
   , parseBool
+  , parseDouble
+  , parsePositiveInt
   ) where
 
 import Data.Aeson (FromJSON(..), ToJSON)
@@ -119,6 +121,13 @@ data AppConfig = AppConfig
   , llmModelPath :: !FilePath
   , llmEnableCleaning :: !Bool
   , llmExtractTodos :: !Bool
+  -- Speaker diarization settings
+  , diarizationEnabled :: !Bool
+  , diarizeBinaryPath :: !FilePath
+  , diarizeSegModelPath :: !FilePath
+  , diarizeEmbModelPath :: !FilePath
+  , diarizeNumSpeakers :: !(Maybe Int)
+  , diarizeClusterThreshold :: !Double
   } deriving (Show, Generic)
 
 -- | Default configuration values
@@ -137,6 +146,13 @@ defaultAppConfig = AppConfig
   , llmModelPath = "llama.cpp/models/tinyllama-1.1b-chat.gguf"
   , llmEnableCleaning = True
   , llmExtractTodos = False
+  -- Diarization defaults
+  , diarizationEnabled = False
+  , diarizeBinaryPath = "sherpa-onnx/build/bin/sherpa-onnx-offline-speaker-diarization"
+  , diarizeSegModelPath = "sherpa-onnx/models/sherpa-onnx-pyannote-segmentation-3-0/model.onnx"
+  , diarizeEmbModelPath = "sherpa-onnx/models/3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx"
+  , diarizeNumSpeakers = Nothing
+  , diarizeClusterThreshold = 0.5
   }
 
 -- | Load configuration from .env file
@@ -162,6 +178,14 @@ loadConfig envFile = do
   llmCleaning' <- readEnvWithDefault "LLM_ENABLE_CLEANING" (llmEnableCleaning defaultAppConfig) parseBool
   llmTodos' <- readEnvWithDefault "LLM_EXTRACT_TODOS" (llmExtractTodos defaultAppConfig) parseBool
 
+  -- Diarization settings
+  diarEnabled' <- readEnvWithDefault "DIARIZATION_ENABLED" (diarizationEnabled defaultAppConfig) parseBool
+  diarBin' <- readEnvWithDefault "DIARIZE_BINARY_PATH" (diarizeBinaryPath defaultAppConfig) Just
+  diarSegModel' <- readEnvWithDefault "DIARIZE_SEGMENTATION_MODEL" (diarizeSegModelPath defaultAppConfig) Just
+  diarEmbModel' <- readEnvWithDefault "DIARIZE_EMBEDDING_MODEL" (diarizeEmbModelPath defaultAppConfig) Just
+  diarSpeakers' <- readEnvWithDefault "DIARIZE_NUM_SPEAKERS" (diarizeNumSpeakers defaultAppConfig) (fmap Just . parsePositiveInt)
+  diarThreshold' <- readEnvWithDefault "DIARIZE_CLUSTER_THRESHOLD" (diarizeClusterThreshold defaultAppConfig) parseDouble
+
   return AppConfig
     { modelSize = modelSize'
     , device = device'
@@ -175,6 +199,12 @@ loadConfig envFile = do
     , llmModelPath = llmModelPath'
     , llmEnableCleaning = llmCleaning'
     , llmExtractTodos = llmTodos'
+    , diarizationEnabled = diarEnabled'
+    , diarizeBinaryPath = diarBin'
+    , diarizeSegModelPath = diarSegModel'
+    , diarizeEmbModelPath = diarEmbModel'
+    , diarizeNumSpeakers = diarSpeakers'
+    , diarizeClusterThreshold = diarThreshold'
     }
 
 -- | Read environment variable with default and parser
@@ -227,6 +257,12 @@ parseTask s = case map toLowerChar s of
   _ -> Nothing
   where
     toLowerChar c = if isAsciiUpper c then toEnum (fromEnum c + 32) else c
+
+parseDouble :: String -> Maybe Double
+parseDouble = readMaybe
+
+parsePositiveInt :: String -> Maybe Int
+parsePositiveInt s = readMaybe s >>= \n -> if n >= 1 then Just n else Nothing
 
 parseSampleRate :: String -> Maybe SampleRate
 parseSampleRate s = readMaybe s >>= mkSampleRate

--- a/src/STT/Diarize.hs
+++ b/src/STT/Diarize.hs
@@ -1,0 +1,150 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module STT.Diarize
+  ( SpeakerInterval(..)
+  , SpeakerTurn(..)
+  , checkDiarizationAvailable
+  , runDiarization
+  , parseDiarizationOutput
+  , assignSpeakers
+  , renderSpeakerTurns
+  , speakerLabels
+  ) where
+
+import Control.Exception (catch, IOException)
+import Control.Monad (filterM)
+import Data.List (maximumBy, minimumBy, nub)
+import Data.Maybe (fromMaybe)
+import Data.Ord (comparing)
+import qualified Data.Text as T
+import Data.Text (Text)
+import System.Directory (doesFileExist)
+import System.Exit (ExitCode(..))
+import System.Process (readProcessWithExitCode)
+import Text.Read (readMaybe)
+
+import STT.Config (AppConfig(..))
+import STT.Whisper (TranscriptSegment(..))
+
+-- | A time interval attributed to one speaker by the diarization backend
+data SpeakerInterval = SpeakerInterval
+  { siStart :: !Double  -- ^ seconds
+  , siEnd :: !Double    -- ^ seconds
+  , siSpeaker :: !Text  -- ^ raw label, e.g. "speaker_00"
+  } deriving (Show, Eq)
+
+-- | A run of consecutive transcript segments spoken by the same speaker
+data SpeakerTurn = SpeakerTurn
+  { stSpeaker :: !Text  -- ^ normalized label, e.g. "Speaker 1"
+  , stStart :: !Double  -- ^ seconds
+  , stEnd :: !Double    -- ^ seconds
+  , stText :: !Text
+  } deriving (Show, Eq)
+
+-- | Verify the sherpa-onnx binary and models are installed
+checkDiarizationAvailable :: AppConfig -> IO (Either String ())
+checkDiarizationAvailable config = do
+  let paths = [ diarizeBinaryPath config
+              , diarizeSegModelPath config
+              , diarizeEmbModelPath config
+              ]
+  missing <- filterM (fmap not . doesFileExist) paths
+  return $ if null missing
+    then Right ()
+    else Left $ "Speaker diarization is not set up. Missing:\n"
+             ++ unlines (map ("  - " ++) missing)
+             ++ "Run ./setup.sh to build sherpa-onnx and download the diarization models."
+
+-- | Run sherpa-onnx speaker diarization on a WAV file (must be 16 kHz)
+runDiarization :: AppConfig -> FilePath -> IO (Either String [SpeakerInterval])
+runDiarization config audioPath = do
+  let clusteringArg = case diarizeNumSpeakers config of
+        Just n -> "--clustering.num-clusters=" ++ show n
+        Nothing -> "--clustering.cluster-threshold=" ++ show (diarizeClusterThreshold config)
+      args = [ "--segmentation.pyannote-model=" ++ diarizeSegModelPath config
+             , "--embedding.model=" ++ diarizeEmbModelPath config
+             , clusteringArg
+             , audioPath
+             ]
+
+  result <- (readProcessWithExitCode (diarizeBinaryPath config) args "" >>= \case
+    (ExitSuccess, stdout, _) -> return $ Right $ parseDiarizationOutput (T.pack stdout)
+    (ExitFailure _, _, stderr) -> return $ Left $ "sherpa-onnx failed: " ++ stderr)
+    `catch` \(e :: IOException) -> return $ Left $ "sherpa-onnx not found: " ++ show e
+
+  case result of
+    Right [] -> return $ Left "sherpa-onnx produced no speaker segments"
+    other -> return other
+
+-- | Parse diarization stdout lines of the form "0.318 -- 6.865 speaker_00",
+-- skipping any log or progress lines that don't match
+parseDiarizationOutput :: Text -> [SpeakerInterval]
+parseDiarizationOutput = concatMap parseLine . T.lines
+  where
+    parseLine line = case T.words line of
+      [startTxt, "--", endTxt, speaker] ->
+        case (readMaybe (T.unpack startTxt), readMaybe (T.unpack endTxt)) of
+          (Just start, Just end) -> [SpeakerInterval start end speaker]
+          _ -> []
+      _ -> []
+
+-- | Assign a speaker to each transcript segment by maximal temporal overlap
+-- with the diarization intervals, then merge consecutive same-speaker
+-- segments into turns. Raw labels are normalized to "Speaker 1", "Speaker 2",
+-- ... in order of first appearance.
+assignSpeakers :: [SpeakerInterval] -> [TranscriptSegment] -> [SpeakerTurn]
+assignSpeakers intervals segments =
+  mergeTurns $ normalizeLabels $ go Nothing segments
+  where
+    go _ [] = []
+    go prevSpeaker (seg:rest) =
+      let speaker = case (segmentFromMs seg, segmentToMs seg) of
+            (Just fromMs, Just toMs) ->
+              pickSpeaker (fromIntegral fromMs / 1000) (fromIntegral toMs / 1000)
+            -- No timestamps: stay with the current speaker
+            _ -> fromMaybe fallbackSpeaker prevSpeaker
+          turn = (speaker, seg)
+      in turn : go (Just speaker) rest
+
+    fallbackSpeaker = case intervals of
+      [] -> "speaker_00"
+      (i:_) -> siSpeaker i
+
+    pickSpeaker segStart segEnd =
+      let bySpeaker = [ (spk, totalOverlap spk) | spk <- nub (map siSpeaker intervals) ]
+          totalOverlap spk = sum [ overlap i | i <- intervals, siSpeaker i == spk ]
+          overlap i = max 0 (min segEnd (siEnd i) - max segStart (siStart i))
+          segMid = (segStart + segEnd) / 2
+          nearest = minimumBy (comparing (\i -> abs ((siStart i + siEnd i) / 2 - segMid))) intervals
+      in case bySpeaker of
+           [] -> fallbackSpeaker
+           _ | all ((<= 0) . snd) bySpeaker -> siSpeaker nearest
+             | otherwise -> fst (maximumBy (comparing snd) bySpeaker)
+
+    normalizeLabels labeled =
+      let order = nub (map fst labeled)
+          rename raw = "Speaker " <> T.pack (show (1 + fromMaybe 0 (lookup raw (zip order [0 :: Int ..]))))
+      in [ (rename raw, seg) | (raw, seg) <- labeled ]
+
+    mergeTurns [] = []
+    mergeTurns ((speaker, seg):rest) =
+      let (same, others) = span ((== speaker) . fst) rest
+          run = seg : map snd same
+          startS = maybe 0 ((/ 1000) . fromIntegral) (segmentFromMs seg)
+          endS = maybe startS ((/ 1000) . fromIntegral) (segmentToMs (last run))
+          text = T.strip $ T.intercalate " " (map (T.strip . segmentText) run)
+      in SpeakerTurn speaker startS endS text : mergeTurns others
+
+-- | Normalized speaker labels present in a set of turns, in order of appearance
+speakerLabels :: [SpeakerTurn] -> [Text]
+speakerLabels = nub . map stSpeaker
+
+-- | Render turns as "<role-or-label>: <text>" paragraphs; the first argument
+-- maps speaker labels to user-confirmed roles
+renderSpeakerTurns :: [(Text, Text)] -> [SpeakerTurn] -> Text
+renderSpeakerTurns roleMap turns =
+  T.intercalate "\n\n" [ label (stSpeaker t) <> ": " <> stText t | t <- turns ]
+  where
+    label spk = fromMaybe spk (lookup spk roleMap)

--- a/src/STT/LLM.hs
+++ b/src/STT/LLM.hs
@@ -8,6 +8,8 @@ module STT.LLM
   , extractReply
   , cleanText
   , extractTodos
+  , suggestSpeakerRoles
+  , parseRoleSuggestions
   ) where
 
 import qualified Data.Text as T
@@ -81,6 +83,30 @@ cleanText llamaBin modelPath rawText = do
       userPrompt = "Fix this transcription:\n\n" <> rawText
 
   callLLM llamaBin modelPath systemPrompt userPrompt
+
+-- | Suggest a role or name for each speaker in a diarized transcript
+suggestSpeakerRoles :: FilePath -> FilePath -> [Text] -> Text -> IO (Either String [(Text, Text)])
+suggestSpeakerRoles llamaBin modelPath speakers transcript = do
+  let systemPrompt = "You are a meeting assistant. Given a transcript with numbered speakers, infer each speaker's likely role or name from what they say (for example 'Interviewer', 'Project lead', or 'Alice' if named). Output exactly one line per speaker in the form 'Speaker N: <role>'. Output nothing else."
+      -- TinyLlama runs with -c 4096; keep the transcript well under that
+      userPrompt = "Identify the role of each speaker ("
+                <> T.intercalate ", " speakers
+                <> ") in this conversation:\n\n"
+                <> T.take 2500 transcript
+
+  result <- callLLM llamaBin modelPath systemPrompt userPrompt
+  return $ fmap (parseRoleSuggestions speakers) result
+
+-- | Extract "Speaker N: role" pairs from LLM output, tolerating noise;
+-- only lines matching a known speaker label are kept
+parseRoleSuggestions :: [Text] -> Text -> [(Text, Text)]
+parseRoleSuggestions speakers output =
+  [ (speaker, role)
+  | line <- map T.strip (T.lines output)
+  , speaker <- take 1 [ s | s <- speakers, (s <> ":") `T.isPrefixOf` line ]
+  , let role = T.strip (T.drop (T.length speaker + 1) line)
+  , not (T.null role)
+  ]
 
 -- | Extract TODO items from meeting transcript
 extractTodos :: FilePath -> FilePath -> Text -> IO (Either String Text)

--- a/src/STT/Markdown.hs
+++ b/src/STT/Markdown.hs
@@ -19,6 +19,11 @@ formatMeetingMinutes result = do
 
   let header = "# Meeting Transcription - " <> T.pack timestamp <> "\n\n"
 
+      speakerSection = case speakerTranscript result of
+        Just turns ->
+          "## Speaker Transcript\n\n" <> turns <> "\n\n"
+        Nothing -> ""
+
       cleanedSection = case cleanedText result of
         Just cleaned ->
           "## Cleaned Transcript\n\n" <> cleaned <> "\n\n"
@@ -40,6 +45,7 @@ formatMeetingMinutes result = do
 
   return $ T.concat
     [ header
+    , speakerSection
     , cleanedSection
     , todosSection
     , originalSection

--- a/src/STT/PostProcess.hs
+++ b/src/STT/PostProcess.hs
@@ -30,6 +30,7 @@ data ProcessedResult = ProcessedResult
   { originalText :: !Text
   , cleanedText :: !(Maybe Text)
   , todos :: !(Maybe Text)
+  , speakerTranscript :: !(Maybe Text)
   , processingErrors :: ![String]
   } deriving (Show, Eq)
 
@@ -60,6 +61,7 @@ processTranscription opts original = do
     { originalText = original
     , cleanedText = cleaned
     , todos = todoList
+    , speakerTranscript = Nothing
     , processingErrors = cleanErr ++ todoErr
     }
 

--- a/src/STT/Whisper.hs
+++ b/src/STT/Whisper.hs
@@ -3,6 +3,9 @@
 
 module STT.Whisper
   ( TranscriptionResult(..)
+  , WhisperCppResponse(..)
+  , TranscriptSegment(..)
+  , ResultInfo(..)
   , transcribeFile
   , transcribeFileWithConfig
   ) where
@@ -23,6 +26,7 @@ data TranscriptionResult = TranscriptionResult
   , transLanguage :: !(Maybe Text)
   , transDuration :: !(Maybe Double)
   , transTranslation :: !(Maybe Text)
+  , transSegments :: ![TranscriptSegment]
   } deriving (Show, Eq, Generic)
 
 -- | JSON response from whisper.cpp
@@ -31,9 +35,13 @@ data WhisperCppResponse = WhisperCppResponse
   , resultInfo :: !(Maybe ResultInfo)
   } deriving (Show, Generic)
 
-newtype TranscriptSegment = TranscriptSegment
-  { segmentText :: Text
-  } deriving (Show, Generic)
+-- | A single transcription segment; offsets are milliseconds from the
+-- start of the audio and absent in JSON emitted by older whisper.cpp builds
+data TranscriptSegment = TranscriptSegment
+  { segmentText :: !Text
+  , segmentFromMs :: !(Maybe Int)
+  , segmentToMs :: !(Maybe Int)
+  } deriving (Show, Eq, Generic)
 
 newtype ResultInfo = ResultInfo
   { detectedLanguage :: Maybe Text
@@ -45,8 +53,14 @@ instance FromJSON WhisperCppResponse where
     <*> v .:? "result"
 
 instance FromJSON TranscriptSegment where
-  parseJSON = withObject "TranscriptSegment" $ \v -> TranscriptSegment
-    <$> v .: "text"
+  parseJSON = withObject "TranscriptSegment" $ \v -> do
+    text <- v .: "text"
+    maybeOffsets <- v .:? "offsets"
+    (fromMs, toMs) <- case maybeOffsets of
+      Nothing -> return (Nothing, Nothing)
+      Just offsets -> flip (withObject "offsets") offsets $ \o ->
+        (,) <$> (Just <$> o .: "from") <*> (Just <$> o .: "to")
+    return $ TranscriptSegment text fromMs toMs
 
 instance FromJSON ResultInfo where
   parseJSON = withObject "ResultInfo" $ \v -> ResultInfo
@@ -110,6 +124,7 @@ transcribeOnly audioPath modelSz _dev lang shouldTranslate = do
             , transLanguage = lang
             , transDuration = Nothing  -- whisper.cpp doesn't provide total duration easily
             , transTranslation = Nothing
+            , transSegments = transcription resp
             }
 
 -- | Transcribe and translate (both modes)

--- a/src/STT/Whisper.hs
+++ b/src/STT/Whisper.hs
@@ -73,8 +73,12 @@ transcribeFileWithConfig config audioPath = do
   let modelSizeStr = modelSizeToString (modelSize config)
       taskMode = task config
       langStr = maybe "auto" T.unpack (language config)
+      -- Speaker alignment needs fine-grained segment timestamps; whisper
+      -- sometimes emits sentence-spanning segments (especially for languages
+      -- without word spacing), which caps how many speakers can be told apart
+      fineSegments = diarizationEnabled config
 
-  transcribeFile audioPath modelSizeStr deviceStr langStr taskMode
+  transcribeFile audioPath modelSizeStr deviceStr langStr fineSegments taskMode
 
 -- | Transcribe audio file with explicit parameters
 transcribeFile
@@ -82,17 +86,18 @@ transcribeFile
   -> String       -- ^ Model size (tiny, base, small, medium, large)
   -> String       -- ^ Device (cpu, cuda)
   -> String       -- ^ Language (auto or language code)
+  -> Bool         -- ^ Split output into fine-grained segments (for diarization)
   -> Task         -- ^ Task mode
   -> IO (Either String TranscriptionResult)
-transcribeFile audioPath modelSz dev lang taskMode =
+transcribeFile audioPath modelSz dev lang fineSegments taskMode =
   case taskMode of
-    Transcribe -> transcribeOnly audioPath modelSz dev lang False
-    Translate -> transcribeOnly audioPath modelSz dev lang True
-    Both -> transcribeBoth audioPath modelSz dev lang
+    Transcribe -> transcribeOnly audioPath modelSz dev lang fineSegments False
+    Translate -> transcribeOnly audioPath modelSz dev lang fineSegments True
+    Both -> transcribeBoth audioPath modelSz dev lang fineSegments
 
 -- | Transcribe only (with optional translation)
-transcribeOnly :: FilePath -> String -> String -> String -> Bool -> IO (Either String TranscriptionResult)
-transcribeOnly audioPath modelSz _dev lang shouldTranslate = do
+transcribeOnly :: FilePath -> String -> String -> String -> Bool -> Bool -> IO (Either String TranscriptionResult)
+transcribeOnly audioPath modelSz _dev lang fineSegments shouldTranslate = do
   let modelPath = "whisper.cpp/models/ggml-" ++ modelSz ++ ".bin"
       jsonOutputPath = audioPath ++ ".json"
       baseArgs = [ "-m", modelPath
@@ -100,9 +105,12 @@ transcribeOnly audioPath modelSz _dev lang shouldTranslate = do
                  , "-l", lang
                  , "-oj"  -- Output JSON to file
                  ]
-      args = if shouldTranslate
-             then baseArgs ++ ["--translate"]
-             else baseArgs
+      -- -ml caps segment length (in tokens); segments are re-merged per
+      -- speaker turn later, so short segments never surface to the user
+      segmentArgs = if fineSegments then ["-ml", "24"] else []
+      args = baseArgs
+             ++ segmentArgs
+             ++ ["--translate" | shouldTranslate]
 
   -- Execute whisper.cpp
   (exitCode, stdout, stderr) <- readProcessWithExitCode "whisper.cpp/build/bin/whisper-cli" args ""
@@ -128,15 +136,15 @@ transcribeOnly audioPath modelSz _dev lang shouldTranslate = do
             }
 
 -- | Transcribe and translate (both modes)
-transcribeBoth :: FilePath -> String -> String -> String -> IO (Either String TranscriptionResult)
-transcribeBoth audioPath modelSz dev lang = do
+transcribeBoth :: FilePath -> String -> String -> String -> Bool -> IO (Either String TranscriptionResult)
+transcribeBoth audioPath modelSz dev lang fineSegments = do
   -- First, transcribe
-  transResult <- transcribeOnly audioPath modelSz dev lang False
+  transResult <- transcribeOnly audioPath modelSz dev lang fineSegments False
   case transResult of
     Left err -> return $ Left err
     Right trans -> do
       -- Then, translate
-      translateResult <- transcribeOnly audioPath modelSz dev lang True
+      translateResult <- transcribeOnly audioPath modelSz dev lang fineSegments True
       case translateResult of
         Left err -> return $ Left err
         Right translation ->

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -10,8 +10,10 @@ import Data.Aeson (decode)
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.List (nub)
 import STT.Config
-import STT.LLM (extractReply)
+import STT.Diarize
+import STT.LLM (extractReply, parseRoleSuggestions)
 import qualified STT.Models as Models
+import STT.Whisper (WhisperCppResponse(..), TranscriptSegment(..), ResultInfo(..))
 
 main :: IO ()
 main = defaultMain tests
@@ -23,6 +25,8 @@ tests = testGroup "Whisper-HS Tests"
   , jsonParsingTests
   , modelRegistryTests
   , extractReplyTests
+  , diarizationTests
+  , roleSuggestionTests
   ]
 
 -- | Test configuration parsers
@@ -66,6 +70,22 @@ configParserTests = testGroup "Config Parsers"
           parseTask "TRANSLATE" @?= Just Translate
       , testCase "parses 'both'" $
           parseTask "both" @?= Just Both
+      ]
+
+  , testGroup "parseDouble"
+      [ testCase "parses '0.5'" $
+          parseDouble "0.5" @?= Just 0.5
+      , testCase "rejects garbage" $
+          parseDouble "high" @?= Nothing
+      ]
+
+  , testGroup "parsePositiveInt"
+      [ testCase "parses '2'" $
+          parsePositiveInt "2" @?= Just 2
+      , testCase "rejects 0" $
+          parsePositiveInt "0" @?= Nothing
+      , testCase "rejects negative" $
+          parsePositiveInt "-3" @?= Nothing
       ]
 
   , testGroup "parseBool"
@@ -114,19 +134,117 @@ validationTests = testGroup "Validation"
       ]
   ]
 
--- | Test JSON parsing (would need actual fixtures)
+-- | Test JSON parsing of whisper.cpp output
 jsonParsingTests :: TestTree
 jsonParsingTests = testGroup "JSON Parsing"
-  [ testCase "parses simple whisper response" $ do
+  [ testCase "parses segment without offsets" $ do
       let json = BSL.pack $ concat
             [ "{"
             , "\"transcription\": [{\"text\": \" Hello world\"}],"
             , "\"result\": {\"language\": \"en\"}"
             , "}"
             ]
-      -- This would need the WhisperCppResponse type to be exported
-      -- For now, just test that it doesn't crash
-      return ()
+      case decode json of
+        Nothing -> assertFailure "failed to decode response"
+        Just resp -> do
+          map segmentText (transcription resp) @?= [" Hello world"]
+          map segmentFromMs (transcription resp) @?= [Nothing]
+          fmap detectedLanguage (resultInfo resp) @?= Just (Just "en")
+
+  , testCase "parses whisper-cli fixture with offsets" $ do
+      json <- BSL.readFile "test/fixtures/whisper-response.json"
+      case decode json of
+        Nothing -> assertFailure "failed to decode fixture"
+        Just resp -> do
+          let segments = transcription resp
+          length segments @?= 1
+          segmentFromMs (head segments) @?= Just 0
+          segmentToMs (head segments) @?= Just 10500
+  ]
+
+-- | Test diarization output parsing and speaker alignment
+diarizationTests :: TestTree
+diarizationTests = testGroup "Diarization"
+  [ testGroup "parseDiarizationOutput"
+      [ testCase "parses well-formed lines" $
+          parseDiarizationOutput "0.318 -- 6.865 speaker_00\n7.010 -- 12.3 speaker_01\n"
+            @?= [ SpeakerInterval 0.318 6.865 "speaker_00"
+                , SpeakerInterval 7.010 12.3 "speaker_01"
+                ]
+      , testCase "skips log noise" $
+          parseDiarizationOutput "Loading model...\n0.5 -- 2.0 speaker_00\nDone in 3s\n"
+            @?= [SpeakerInterval 0.5 2.0 "speaker_00"]
+      , testCase "skips lines with unreadable times" $
+          parseDiarizationOutput "abc -- def speaker_00\n" @?= []
+      , testCase "handles empty input" $
+          parseDiarizationOutput "" @?= []
+      ]
+
+  , testGroup "assignSpeakers"
+      [ testCase "assigns by overlap and merges consecutive turns" $ do
+          let intervals = [ SpeakerInterval 0 5 "speaker_00"
+                          , SpeakerInterval 5 10 "speaker_01"
+                          ]
+              segments = [ seg " Hi." 0 2000
+                         , seg " How are you?" 2000 4500
+                         , seg " Fine, thanks." 5500 9000
+                         ]
+          assignSpeakers intervals segments
+            @?= [ SpeakerTurn "Speaker 1" 0 4.5 "Hi. How are you?"
+                , SpeakerTurn "Speaker 2" 5.5 9 "Fine, thanks."
+                ]
+      , testCase "straddling segment goes to larger overlap" $ do
+          let intervals = [ SpeakerInterval 0 3 "speaker_00"
+                          , SpeakerInterval 3 10 "speaker_01"
+                          ]
+              segments = [seg " Borderline." 2000 8000]
+          map stSpeaker (assignSpeakers intervals segments) @?= ["Speaker 1"]
+            -- speaker_01 overlaps 5s vs 1s for speaker_00, but labels are
+            -- normalized by first appearance, so speaker_01 becomes Speaker 1
+      , testCase "segment in a silence gap uses nearest interval" $ do
+          let intervals = [ SpeakerInterval 0 2 "speaker_00"
+                          , SpeakerInterval 8 10 "speaker_01"
+                          ]
+              segments = [seg " Lost in the gap." 6500 7500]
+          map stSpeaker (assignSpeakers intervals segments) @?= ["Speaker 1"]
+      , testCase "no intervals yields a single speaker" $ do
+          let segments = [ seg " One." 0 1000
+                         , seg " Two." 1000 2000
+                         ]
+          assignSpeakers [] segments
+            @?= [SpeakerTurn "Speaker 1" 0 2 "One. Two."]
+      , testCase "segments without offsets inherit the previous speaker" $ do
+          let intervals = [SpeakerInterval 0 5 "speaker_00"]
+              segments = [ seg " Timed." 0 2000
+                         , TranscriptSegment " Untimed." Nothing Nothing
+                         ]
+          map stSpeaker (assignSpeakers intervals segments) @?= ["Speaker 1"]
+      ]
+
+  , testGroup "renderSpeakerTurns"
+      [ testCase "applies confirmed roles, keeping labels without one" $ do
+          let turns = [ SpeakerTurn "Speaker 1" 0 5 "Hello."
+                      , SpeakerTurn "Speaker 2" 5 9 "Hi there."
+                      ]
+          renderSpeakerTurns [("Speaker 1", "Interviewer")] turns
+            @?= "Interviewer: Hello.\n\nSpeaker 2: Hi there."
+      ]
+  ]
+  where
+    seg t fromMs toMs = TranscriptSegment t (Just fromMs) (Just toMs)
+
+-- | Test lenient parsing of LLM role suggestions
+roleSuggestionTests :: TestTree
+roleSuggestionTests = testGroup "Role Suggestions"
+  [ testCase "extracts known speakers from noisy output" $
+      parseRoleSuggestions ["Speaker 1", "Speaker 2"]
+        "Sure! Here are the roles:\nSpeaker 1: Alice\n\nSpeaker 2: Interviewer\nHope that helps!"
+        @?= [("Speaker 1", "Alice"), ("Speaker 2", "Interviewer")]
+  , testCase "ignores unknown speaker labels" $
+      parseRoleSuggestions ["Speaker 1"] "Speaker 3: Ghost\nSpeaker 1: Bob"
+        @?= [("Speaker 1", "Bob")]
+  , testCase "drops empty roles" $
+      parseRoleSuggestions ["Speaker 1"] "Speaker 1:  " @?= []
   ]
 
 -- | Sanity checks on the curated LLM registry

--- a/whisper-hs.cabal
+++ b/whisper-hs.cabal
@@ -31,6 +31,7 @@ library
     STT.Audio
     STT.Whisper
     STT.App
+    STT.Diarize
     STT.LLM
     STT.Models
     STT.PostProcess


### PR DESCRIPTION
## Summary

Distinguishes voices in recordings and labels the transcript per speaker, with LLM-suggested roles the user confirms interactively.

- **Diarization backend**: vendored [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) (C++ CLI, no Python), using pyannote segmentation-3.0 + 3D-Speaker ERes2Net embedding ONNX models. `setup.sh` gains a step that builds the binary and downloads both models (skipped with a warning if cmake is missing).
- **New module `STT.Diarize`**: runs the CLI, parses its `start -- end speaker_NN` output, aligns speaker intervals with whisper segment timestamps by maximal overlap (nearest-midpoint fallback for silence gaps), merges consecutive same-speaker segments into turns, and renders `Speaker N: …` transcripts.
- **Whisper JSON parser** now retains per-segment `offsets` (ms) via `TranscriptSegment`, and `WhisperCppResponse` is exported — the previously stubbed JSON test is now real.
- **Role assignment**: `STT.LLM.suggestSpeakerRoles` asks the local LLM to infer a role/name per speaker; the user accepts, overrides, or discards each suggestion in the terminal. The final speaker transcript is displayed and saved as Markdown (`## Speaker Transcript` section).
- **Config/menu**: `DIARIZATION_ENABLED`, `DIARIZE_BINARY_PATH`, `DIARIZE_SEGMENTATION_MODEL`, `DIARIZE_EMBEDDING_MODEL`, `DIARIZE_NUM_SPEAKERS`, `DIARIZE_CLUSTER_THRESHOLD` env vars plus a "Toggle speaker diarization" menu entry (warns when sample rate ≠ 16 kHz, which sherpa-onnx requires). Missing binary/models degrade gracefully to the plain transcript with a setup hint.
- Also fixes a latent temp-file leak: the whisper `-oj` JSON sidecar is now removed together with the recording.

## Test plan

- [x] `cabal build` clean, HLint clean
- [x] `cabal test` — 50 tests pass, including new coverage for diarization output parsing, speaker alignment edge cases (straddling segments, silence gaps, missing offsets, empty diarization), role-suggestion parsing, and whisper JSON offsets
- [ ] End-to-end with a two-speaker WAV after running `setup.sh` (requires building sherpa-onnx + model downloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)