### PR TITLE
Make the LLM layer model-agnostic with a curated model chooser

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,10 @@ KEEP_RECORDINGS=false
 # Path to llama.cpp binary (new CMake build location)
 LLM_BINARY_PATH=llama.cpp/build/bin/llama-cli
 
-# Path to LLM model file (TinyLlama recommended for speed)
+# Path to LLM model file. Any instruct model in GGUF format works — the
+# chat template embedded in the file is applied automatically. The app's
+# "Change LLM model" menu can download curated options (TinyLlama 1.1B,
+# Llama 3.2 3B, Qwen3 4B, Qwen2.5 7B) or point this at your own GGUF.
 LLM_MODEL_PATH=llama.cpp/models/tinyllama-1.1b-chat.gguf
 
 # Enable automatic text cleaning (grammar/punctuation fixes): true, false

--- a/src/STT/App.hs
+++ b/src/STT/App.hs
@@ -23,6 +23,7 @@ import STT.Config (AppConfig(..), Task(..))
 import qualified STT.Config as Config
 import qualified STT.Audio as Audio
 import qualified STT.Whisper as Whisper
+import qualified STT.Models as Models
 import qualified STT.PostProcess as PostProcess
 import qualified STT.Markdown as Markdown
 
@@ -50,14 +51,15 @@ runApp initialConfig = do
     putStrLn "Configuration:"
     putStrLn "  3. List audio devices"
     putStrLn "  4. Change language settings"
+    putStrLn "  5. Change LLM model"
     putStrLn ""
     putStrLn "Post-Processing:"
-    putStrLn "  5. Clean transcription file"
-    putStrLn "  6. Extract TODOs from file"
+    putStrLn "  6. Clean transcription file"
+    putStrLn "  7. Extract TODOs from file"
     putStrLn ""
-    putStrLn "  7. Quit"
+    putStrLn "  8. Quit"
     putStrLn ""
-    putStr "Choose an option (1-7): "
+    putStr "Choose an option (1-8): "
     hFlush stdout
 
     choice <- getLine
@@ -70,12 +72,13 @@ runApp initialConfig = do
       "2" -> transcribeExistingMenu config
       "3" -> listDevicesMenu
       "4" -> changeLanguageMenu configRef
-      "5" -> cleanTranscriptionMenu config
-      "6" -> extractTodosMenu config
-      "7" -> do
+      "5" -> changeLlmModelMenu configRef
+      "6" -> cleanTranscriptionMenu config
+      "7" -> extractTodosMenu config
+      "8" -> do
         putStrLn "Goodbye!"
         exitSuccess
-      _ -> putStrLn "Invalid choice. Please choose 1-7."
+      _ -> putStrLn "Invalid choice. Please choose 1-8."
 
 -- | Print current configuration
 printConfig :: AppConfig -> IO ()
@@ -90,6 +93,7 @@ printConfig config = do
   putStrLn $ "  Language: " ++ maybe "auto" T.unpack (language config)
   putStrLn $ "  Task: " ++ show (task config)
   putStrLn $ "  Keep Recordings: " ++ show (keepRecordings config)
+  putStrLn $ "  LLM Model: " ++ llmModelPath config
 
 -- | Menu for recording and transcribing
 recordAndTranscribeMenu :: AppConfig -> IO ()
@@ -259,6 +263,72 @@ extractTodosMenu config = do
       putStrLn "========================================="
       TIO.putStrLn todos
       putStrLn "========================================="
+
+-- | Menu for choosing (and if necessary downloading) the LLM model used
+-- for post-processing. Any instruct GGUF works; the curated list covers
+-- the speed/quality range for CPU inference.
+changeLlmModelMenu :: IORef AppConfig -> IO ()
+changeLlmModelMenu configRef = do
+  config <- readIORef configRef
+
+  putStrLn $ "Current LLM model: " ++ llmModelPath config
+  putStrLn ""
+  putStrLn "Available models:"
+  mapM_ (printModel config) (zip [1 :: Int ..] Models.knownModels)
+  putStrLn ""
+  putStr "Choose a model number, or type a path to any instruct GGUF (Enter to keep current): "
+  hFlush stdout
+
+  input <- getLine
+  case input of
+    "" -> putStrLn "LLM model unchanged."
+    _ | Just n <- readMaybe input :: Maybe Int
+      , Just spec <- lookup n (zip [1 ..] Models.knownModels) -> selectModel spec
+      | otherwise -> selectPath input
+  where
+    printModel config (n, spec) = do
+      installed <- Models.isInstalled spec
+      let markers = concat
+            [ if Models.modelPath spec == llmModelPath config then " [current]" else ""
+            , if installed then " [installed]" else ""
+            ]
+      putStrLn $ "  " ++ show n ++ ". " ++ Models.modelLabel spec
+              ++ " (" ++ Models.formatSize (Models.modelSizeMB spec) ++ ")"
+              ++ markers
+      putStrLn $ "       " ++ Models.modelNotes spec
+
+    selectModel spec = do
+      installed <- Models.isInstalled spec
+      if installed
+        then setModelPath (Models.modelPath spec)
+        else do
+          putStr $ "Download " ++ Models.modelLabel spec
+                ++ " (" ++ Models.formatSize (Models.modelSizeMB spec)
+                ++ ")? (Enter to download, anything else cancels): "
+          hFlush stdout
+          answer <- getLine
+          if null answer
+            then do
+              result <- Models.downloadModel spec
+              case result of
+                Left err -> putStrLn err
+                Right path -> setModelPath path
+            else putStrLn "Download cancelled."
+
+    selectPath path = do
+      exists <- doesFileExist path
+      if exists
+        then setModelPath path
+        else putStrLn $ "File not found: " ++ path
+
+    setModelPath path = do
+      config <- readIORef configRef
+      let newConfig = config { llmModelPath = path }
+      writeIORef configRef newConfig
+      putStrLn $ "LLM model changed to: " ++ path
+      putStrLn ""
+      putStrLn "Updated configuration:"
+      printConfig newConfig
 
 -- | Menu for changing language settings
 changeLanguageMenu :: IORef AppConfig -> IO ()

--- a/src/STT/LLM.hs
+++ b/src/STT/LLM.hs
@@ -5,6 +5,7 @@
 module STT.LLM
   ( LLMResponse(..)
   , callLLM
+  , extractReply
   , cleanText
   , extractTodos
   ) where
@@ -22,7 +23,9 @@ data LLMResponse = LLMResponse
   , errorMsg :: !(Maybe String)
   } deriving (Show, Eq)
 
--- | Call llama.cpp with a prompt
+-- | Call llama.cpp with a prompt. The chat template embedded in the GGUF is
+-- applied by llama-cli itself (conversation mode), so any instruct model
+-- works here — nothing is hardcoded to a particular model family.
 callLLM
   :: FilePath  -- ^ Path to llama.cpp binary
   -> FilePath  -- ^ Path to model file
@@ -30,14 +33,15 @@ callLLM
   -> Text      -- ^ User prompt
   -> IO (Either String Text)
 callLLM llamaBin modelPath systemPrompt userPrompt = do
-  let fullPrompt = formatPrompt systemPrompt userPrompt
-      args = [ "-m", modelPath
-             , "-p", T.unpack fullPrompt
+  let args = [ "-m", modelPath
+             , "-sys", T.unpack systemPrompt
+             , "-p", T.unpack userPrompt
+             , "-st"  -- single conversation turn, then exit
+             , "--simple-io"  -- no spinner/ANSI escapes in subprocess output
              , "-n", "2048"  -- Max tokens
              , "--temp", "0.3"  -- Low temperature for consistency
              , "--top-p", "0.9"
              , "-c", "4096"  -- Context size
-             , "--no-display-prompt"  -- Don't echo the prompt
              ]
 
   result <- (readProcessWithExitCode llamaBin args "" >>= \case
@@ -46,13 +50,25 @@ callLLM llamaBin modelPath systemPrompt userPrompt = do
     `catch` \(e :: IOException) -> return $ Left $ "llama.cpp not found: " ++ show e
 
   case result of
-    Right text -> return $ Right $ cleanLLMOutput text
+    Right text -> return $ Right $ extractReply userPrompt text
     Left err -> return $ Left err
 
--- | Format prompt for TinyLlama-Chat format
-formatPrompt :: Text -> Text -> Text
-formatPrompt systemPrompt userPrompt =
-  "<|system|>\n" <> systemPrompt <> "\n<|user|>\n" <> userPrompt <> "\n<|assistant|>\n"
+-- | Extract the assistant reply from llama-cli's conversation-mode stdout.
+-- The stream is: banner noise, the user prompt echoed after a "> " marker,
+-- the reply, then a "[ Prompt: ... ]" stats trailer and "Exiting...".
+extractReply :: Text -> Text -> Text
+extractReply userPrompt out = cleanLLMOutput (T.unlines reply)
+  where
+    allLines = T.lines out
+    promptLineCount = length (T.lines userPrompt)
+    afterEcho = case break ("> " `T.isPrefixOf`) allLines of
+      -- No echo marker (unexpected build): keep everything before the trailer
+      (_, []) -> allLines
+      -- The echo spans the "> " line plus the remaining prompt lines
+      (_, _echoStart:rest) -> drop (promptLineCount - 1) rest
+    reply = takeWhile (not . isTrailer) afterEcho
+    isTrailer line =
+      "[ Prompt:" `T.isPrefixOf` T.strip line || T.strip line == "Exiting..."
 
 -- | Clean LLM output (remove extra whitespace, trailing artifacts)
 cleanLLMOutput :: Text -> Text

--- a/src/STT/Models.hs
+++ b/src/STT/Models.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module STT.Models
+  ( ModelSpec(..)
+  , knownModels
+  , modelsDir
+  , modelPath
+  , isInstalled
+  , downloadModel
+  , formatSize
+  ) where
+
+import Control.Exception (catch, try, IOException, SomeException)
+import Control.Monad (when)
+import System.Directory (createDirectoryIfMissing, doesFileExist, removeFile, renameFile)
+import System.FilePath ((</>))
+import System.Process (callProcess, readProcessWithExitCode)
+import Text.Printf (printf)
+
+-- | A curated, known-good instruct model in GGUF format. Any of these works
+-- with the template-agnostic LLM layer; they differ in speed and quality.
+data ModelSpec = ModelSpec
+  { modelKey :: !String     -- ^ short stable identifier
+  , modelLabel :: !String   -- ^ human-readable name
+  , modelFile :: !FilePath  -- ^ file name under 'modelsDir'
+  , modelUrl :: !String     -- ^ direct GGUF download URL
+  , modelSizeMB :: !Int     -- ^ approximate download size
+  , modelNotes :: !String   -- ^ one-line guidance for choosing
+  } deriving (Show, Eq)
+
+modelsDir :: FilePath
+modelsDir = "llama.cpp/models"
+
+-- | Curated models, ordered small to large. All are Q4_K_M quantizations
+-- suitable for CPU inference.
+knownModels :: [ModelSpec]
+knownModels =
+  [ ModelSpec
+      { modelKey = "tinyllama-1.1b"
+      , modelLabel = "TinyLlama 1.1B Chat"
+      , modelFile = "tinyllama-1.1b-chat.gguf"
+      , modelUrl = "https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf"
+      , modelSizeMB = 669
+      , modelNotes = "fastest, lowest quality (setup.sh default)"
+      }
+  , ModelSpec
+      { modelKey = "llama3.2-3b"
+      , modelLabel = "Llama 3.2 3B Instruct"
+      , modelFile = "llama-3.2-3b-instruct-q4_k_m.gguf"
+      , modelUrl = "https://huggingface.co/bartowski/Llama-3.2-3B-Instruct-GGUF/resolve/main/Llama-3.2-3B-Instruct-Q4_K_M.gguf"
+      , modelSizeMB = 2020
+      , modelNotes = "fast with solid quality"
+      }
+  , ModelSpec
+      { modelKey = "qwen3-4b"
+      , modelLabel = "Qwen3 4B Instruct"
+      , modelFile = "qwen3-4b-instruct-2507-q4_k_m.gguf"
+      , modelUrl = "https://huggingface.co/unsloth/Qwen3-4B-Instruct-2507-GGUF/resolve/main/Qwen3-4B-Instruct-2507-Q4_K_M.gguf"
+      , modelSizeMB = 2500
+      , modelNotes = "recommended: strong multilingual quality at good speed"
+      }
+  , ModelSpec
+      { modelKey = "qwen2.5-7b"
+      , modelLabel = "Qwen2.5 7B Instruct"
+      , modelFile = "qwen2.5-7b-instruct-q4_k_m.gguf"
+      , modelUrl = "https://huggingface.co/bartowski/Qwen2.5-7B-Instruct-GGUF/resolve/main/Qwen2.5-7B-Instruct-Q4_K_M.gguf"
+      , modelSizeMB = 4680
+      , modelNotes = "best quality, noticeably slower on CPU"
+      }
+  ]
+
+modelPath :: ModelSpec -> FilePath
+modelPath spec = modelsDir </> modelFile spec
+
+isInstalled :: ModelSpec -> IO Bool
+isInstalled = doesFileExist . modelPath
+
+-- | Human-readable size, e.g. "0.7 GB"
+formatSize :: Int -> String
+formatSize mb = printf "%.1f GB" (fromIntegral mb / 1024 :: Double)
+
+-- | Download a model with wget or curl (whichever is available), showing
+-- their progress output. Downloads go to a ".part" file first so an
+-- interrupted transfer never leaves a half-written model behind.
+downloadModel :: ModelSpec -> IO (Either String FilePath)
+downloadModel spec = do
+  createDirectoryIfMissing True modelsDir
+  let dest = modelPath spec
+      partial = dest ++ ".part"
+
+  result <- try (fetch (modelUrl spec) partial)
+  case result of
+    Left (e :: SomeException) -> do
+      partialExists <- doesFileExist partial
+      when partialExists $ removeFile partial
+      return $ Left $ "Download failed: " ++ show e
+    Right () -> do
+      renameFile partial dest
+      return $ Right dest
+
+-- | Fetch a URL, preferring wget for its resumable, progress-friendly output
+fetch :: String -> FilePath -> IO ()
+fetch url dest = do
+  wgetAvailable <- commandExists "wget"
+  if wgetAvailable
+    then callProcess "wget" [url, "-O", dest]
+    else callProcess "curl" ["-L", "--fail", "--progress-bar", "-o", dest, url]
+
+commandExists :: String -> IO Bool
+commandExists cmd =
+  (True <$ readProcessWithExitCode cmd ["--version"] "")
+    `catch` \(_ :: IOException) -> return False

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -8,7 +8,10 @@ import Test.Tasty.QuickCheck (Arbitrary(..), elements)
 import qualified Data.Text as T
 import Data.Aeson (decode)
 import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (nub)
 import STT.Config
+import STT.LLM (extractReply)
+import qualified STT.Models as Models
 
 main :: IO ()
 main = defaultMain tests
@@ -18,6 +21,8 @@ tests = testGroup "Whisper-HS Tests"
   [ configParserTests
   , validationTests
   , jsonParsingTests
+  , modelRegistryTests
+  , extractReplyTests
   ]
 
 -- | Test configuration parsers
@@ -122,6 +127,62 @@ jsonParsingTests = testGroup "JSON Parsing"
       -- This would need the WhisperCppResponse type to be exported
       -- For now, just test that it doesn't crash
       return ()
+  ]
+
+-- | Sanity checks on the curated LLM registry
+modelRegistryTests :: TestTree
+modelRegistryTests = testGroup "Model Registry"
+  [ testCase "keys are unique" $
+      length (nub (map Models.modelKey Models.knownModels))
+        @?= length Models.knownModels
+  , testCase "file names are unique" $
+      length (nub (map Models.modelFile Models.knownModels))
+        @?= length Models.knownModels
+  , testCase "URLs are https" $
+      assertBool "all https" (all (("https://" ==) . take 8 . Models.modelUrl) Models.knownModels)
+  , testCase "sizes are positive" $
+      assertBool "positive sizes" (all ((> 0) . Models.modelSizeMB) Models.knownModels)
+  , testCase "default setup model is in the registry" $
+      assertBool "tinyllama present"
+        (any (("tinyllama-1.1b-chat.gguf" ==) . Models.modelFile) Models.knownModels)
+  ]
+
+-- | Test extraction of the assistant reply from llama-cli stdout
+extractReplyTests :: TestTree
+extractReplyTests = testGroup "extractReply"
+  [ testCase "single-line prompt" $
+      extractReply "What color is the sky?"
+        (T.unlines
+          [ "build      : b8831"
+          , "available commands:"
+          , "  /exit or Ctrl+C     stop or exit"
+          , ""
+          , "> What color is the sky?"
+          , ""
+          , "Blue."
+          , ""
+          , "[ Prompt: 159,6 t/s | Generation: 51,5 t/s ]"
+          , ""
+          , "Exiting..."
+          ])
+        @?= "Blue."
+  , testCase "multi-line prompt echo is skipped" $
+      extractReply "fix this:\n\nme and him goes\nthey was happy"
+        (T.unlines
+          [ "banner"
+          , "> fix this:"
+          , ""
+          , "me and him goes"
+          , "they was happy"
+          , ""
+          , "He and I went."
+          , "They were happy."
+          , ""
+          , "[ Prompt: 102,8 t/s ]"
+          ])
+        @?= "He and I went.\nThey were happy."
+  , testCase "no echo marker falls back to trailer-stripped output" $
+      extractReply "prompt" "Some reply.\nExiting...\n" @?= "Some reply."
   ]
 
 -- | Property-based tests

--- a/whisper-hs.cabal
+++ b/whisper-hs.cabal
@@ -32,6 +32,7 @@ library
     STT.Whisper
     STT.App
     STT.LLM
+    STT.Models
     STT.PostProcess
     STT.Markdown
   build-depends:


### PR DESCRIPTION
## Summary

Decouples post-processing from TinyLlama so any instruct GGUF can be used, and adds an in-app way to pick or download better models.

- **Template-agnostic `callLLM`**: instead of hardcoding TinyLlama's `<|system|>/<|user|>/<|assistant|>` format, llama-cli now runs in single-turn conversation mode (`-sys`/`-p`/`-st`/`--simple-io`), which applies the chat template embedded in the GGUF itself. A new `extractReply` function parses the assistant reply out of the conversation-mode stdout (banner, echoed prompt, and stats trailer stripped); its behavior is pinned by tests replicating real llama-cli output.
- **New `STT.Models` registry** of curated CPU-friendly Q4_K_M models with verified download URLs:
  - TinyLlama 1.1B Chat (~0.7 GB) — fastest, lowest quality (setup default)
  - Llama 3.2 3B Instruct (~2.0 GB) — fast with solid quality
  - Qwen3 4B Instruct (~2.5 GB) — recommended: strong multilingual quality at good speed
  - Qwen2.5 7B Instruct (~4.6 GB) — best quality, slower on CPU
- **"Change LLM model" menu**: lists the curated models with size/installed/current markers, downloads on selection (wget/curl with progress, `.part` staging so interrupted downloads never leave a broken model), and also accepts a filesystem path to any custom GGUF. The choice updates `llmModelPath` at runtime; `LLM_MODEL_PATH` in `.env` persists it.

Verified end-to-end against the vendored llama-cli (b8831) with TinyLlama: the conversation-mode invocation and reply extraction work through the real code path.

## Test plan

- [x] `cabal build` warning-free, HLint clean
- [x] `cabal test` — 39 tests pass (registry sanity + `extractReply` on real captured llama-cli output shapes)
- [x] Live `cleanText` call through the new layer against the vendored binary
- [ ] Download a curated model via the menu and run cleaning with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)